### PR TITLE
Add Flutter network monitor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.PHONY: install-deps run build build-windows run-docker
+
+install-deps:
+cd flutter_network_monitor && flutter pub get
+
+run:
+cd flutter_network_monitor && flutter run
+
+build:
+cd flutter_network_monitor && flutter build linux
+
+build-windows:
+cd flutter_network_monitor && flutter build windows
+
+run-docker:
+docker run --rm -it -v $(PWD)/flutter_network_monitor:/app -w /app ghcr.io/cirruslabs/flutter:latest flutter run

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,16 @@
 .PHONY: install-deps run build build-windows run-docker
 
 install-deps:
-cd flutter_network_monitor && flutter pub get
+	cd flutter_network_monitor && flutter pub get
 
 run:
-cd flutter_network_monitor && flutter run
+	cd flutter_network_monitor && flutter run
 
 build:
-cd flutter_network_monitor && flutter build linux
+	cd flutter_network_monitor && flutter build linux
 
 build-windows:
-cd flutter_network_monitor && flutter build windows
+	cd flutter_network_monitor && flutter build windows
 
 run-docker:
-docker run --rm -it -v $(PWD)/flutter_network_monitor:/app -w /app ghcr.io/cirruslabs/flutter:latest flutter run
+	docker run --rm -it -v $(PWD)/flutter_network_monitor:/app -w /app ghcr.io/cirruslabs/flutter:latest flutter run

--- a/README.md
+++ b/README.md
@@ -8,8 +8,39 @@ Windows and Linux.
 - [Flutter](https://docs.flutter.dev/get-started/install) SDK
 
 ## Running
+You can run the application directly with Flutter or via the provided Makefile.
+
 ```
-flutter run
+make run
+```
+
+Before running for the first time, install dependencies:
+
+```
+make install-deps
+```
+
+### Docker
+
+If you don't have Flutter installed locally you can run it inside a Docker
+container:
+
+```
+make run-docker
+```
+
+### Building
+
+To build a release binary for Linux:
+
+```
+make build
+```
+
+And for Windows:
+
+```
+make build-windows
 ```
 
 By default it will monitor the first non-loopback interface. Edit

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # network-monitor
-A network monitor tool for windows and linux
+
+A cross platform network monitor tool built with Flutter. It displays a simple
+line chart of network traffic for the selected interface and works on both
+Windows and Linux.
+
+## Requirements
+- [Flutter](https://docs.flutter.dev/get-started/install) SDK
+
+## Running
+```
+flutter run
+```
+
+By default it will monitor the first non-loopback interface. Edit
+`readNetworkStats` in `lib/network_stats.dart` to specify a different interface
+or modify the logic to list available interfaces.

--- a/flutter_network_monitor/lib/main.dart
+++ b/flutter_network_monitor/lib/main.dart
@@ -1,0 +1,81 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:fl_chart/fl_chart.dart';
+import 'network_stats.dart';
+
+void main() {
+  runApp(const NetworkMonitorApp());
+}
+
+class NetworkMonitorApp extends StatelessWidget {
+  const NetworkMonitorApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(
+      home: NetworkMonitorHome(),
+    );
+  }
+}
+
+class NetworkMonitorHome extends StatefulWidget {
+  const NetworkMonitorHome({super.key});
+
+  @override
+  State<NetworkMonitorHome> createState() => _NetworkMonitorHomeState();
+}
+
+class _NetworkMonitorHomeState extends State<NetworkMonitorHome> {
+  final List<FlSpot> _rxData = [];
+  final List<FlSpot> _txData = [];
+  late Timer _timer;
+  late DateTime _start;
+
+  @override
+  void initState() {
+    super.initState();
+    _start = DateTime.now();
+    _timer = Timer.periodic(const Duration(seconds: 1), (_) async {
+      final stats = await readNetworkStats();
+      final seconds = DateTime.now().difference(_start).inSeconds.toDouble();
+      setState(() {
+        _rxData.add(FlSpot(seconds, stats.rx.toDouble()));
+        _txData.add(FlSpot(seconds, stats.tx.toDouble()));
+        if (_rxData.length > 60) {
+          _rxData.removeAt(0);
+          _txData.removeAt(0);
+        }
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    _timer.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Network Monitor')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: LineChart(
+          LineChartData(
+            titlesData: FlTitlesData(
+              leftTitles: AxisTitles(sideTitles: SideTitles(showTitles: true)),
+              bottomTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+              rightTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+              topTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+            ),
+            lineBarsData: [
+              LineChartBarData(spots: _rxData, color: Colors.blue),
+              LineChartBarData(spots: _txData, color: Colors.red),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/flutter_network_monitor/lib/network_stats.dart
+++ b/flutter_network_monitor/lib/network_stats.dart
@@ -1,0 +1,48 @@
+import 'dart:io';
+import 'package:process_run/process_run.dart';
+
+class NetworkStats {
+  final int rx;
+  final int tx;
+  NetworkStats(this.rx, this.tx);
+}
+
+Future<NetworkStats> readNetworkStats([String? interface]) async {
+  if (Platform.isLinux) {
+    final lines = await File('/proc/net/dev').readAsLines();
+    final target = interface ?? _firstInterfaceLinux(lines);
+    for (final line in lines) {
+      if (line.trim().startsWith('$target:')) {
+        final parts = line.split(':')[1].trim().split(RegExp(r'\s+'));
+        final rx = int.parse(parts[0]);
+        final tx = int.parse(parts[8]);
+        return NetworkStats(rx, tx);
+      }
+    }
+  } else if (Platform.isWindows) {
+    final result = await run('powershell', [
+      '-Command',
+      'Get-NetAdapterStatistics -Name ${interface ?? '*'} | Format-Table -HideTableHeaders ReceivedBytes,SentBytes'
+    ]);
+    if (result.exitCode == 0 && result.stdout is String) {
+      final lines = (result.stdout as String).trim().split('\n');
+      if (lines.isNotEmpty) {
+        final parts = lines[0].trim().split(RegExp(r'\s+'));
+        if (parts.length >= 2) {
+          final rx = int.parse(parts[0]);
+          final tx = int.parse(parts[1]);
+          return NetworkStats(rx, tx);
+        }
+      }
+    }
+  }
+  return NetworkStats(0, 0);
+}
+
+String _firstInterfaceLinux(List<String> lines) {
+  for (final line in lines.skip(2)) {
+    final name = line.split(':')[0].trim();
+    if (name != 'lo') return name;
+  }
+  return 'lo';
+}

--- a/flutter_network_monitor/pubspec.yaml
+++ b/flutter_network_monitor/pubspec.yaml
@@ -1,0 +1,16 @@
+name: flutter_network_monitor
+version: 0.1.0
+publish_to: none
+environment:
+  sdk: '>=2.18.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  fl_chart: ^0.63.0
+
+  # to run OS commands
+  process_run: ^0.12.2
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- create Flutter project skeleton for monitoring network traffic
- implement cross-platform network stats collector
- visualize RX/TX data with `fl_chart`
- document how to run the tool

## Testing
- `flutter pub get` *(fails: `flutter` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686d925731a8832a8281dbd8b6deeed1